### PR TITLE
Disable sha512 checksum files for Bintray

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 kotlin.code.style=official
+# Enable old MD5 checksum files, because Bintray gets confused by new SHA checksum files
+# See also https://github.com/gradle/gradle/issues/11412
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Enable old MD5 checksum files, because Bintray gets confused by new SHA checksum files, see https://github.com/gradle/gradle/issues/11412