### PR TITLE
Switch to GitHub Packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,12 +45,12 @@ java {
 
 publishing {
     repositories {
-        jcenter {
-            name = "Bintray"
-            url = uri("https://api.bintray.com/maven/grandcentrix/maven/kotlin-either/;publish=1")
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/grandcentrix/grandcentrix-kotlin-either")
             credentials {
-                username = project.findProperty("bintray.user")?.toString() ?: System.getenv("BINTRAY_USER")
-                password = project.findProperty("bintray.token")?.toString() ?: System.getenv("BINTRAY_TOKEN")
+                username = project.findProperty("github.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("github.token")?.toString() ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,1 @@
 kotlin.code.style=official
-# Enable old MD5 checksum files, because Bintray gets confused by new SHA checksum files
-# See also https://github.com/gradle/gradle/issues/11412
-systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
#### Description:

Switching to GitHub Packages as JCenter is deprecated since yesterday (see https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)