### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,29 @@
 
 ![Publish Artifact](https://github.com/grandcentrix/grandcentrix-kotlin-either/workflows/Publish%20Artifact/badge.svg)
 
-Functional Error/Success Handling
+## Functional Error/Success Handling
 
-Provides an algebraic data type which is **either** a **failure** or a **success**.
-
-Both `Success` and `Failure` classes extend sealed class `Either` so they can be type checked exhaustively in Kotlin expressions without the need for an `else` branch:
-
-```
-val result = 
-    when(either) {
-        is Failure -> ...
-        is Success -> ...
-    }
-```
+Provides an algebraic data type which is **either** a **failure** or a **success**. 
+It is implemented as a `sealed class Either` with two child classes: `Success` and `Failure`.
 
 `Success` and `Failure` are wrappers which can wrap any type, like e.g. a response from an HTTP request or an HTTP error. Exceptions can of course be wrapped in `Failure` as well.
 
 In Kotlin this provides an advantage over `try/catch` blocks in that it requires the `Either` consumer to actually handle the error case, as in Kotlin there are no checked exceptions.
 This is because exceptions should be used for exceptional situations, which cannot be predicted while writing the program, like programmer errors. In this case the application should crash early and crash hard so that the programmer can find the issue early and fix it.
-Errors like HTTP 404, which **SHOULD** be handled in the application and not crash, error types should be used. `Either` is perfect for this.
+For domain errors like HTTP 404, which **SHOULD** be handled in the application and not crash, error types should be used. `Either` is perfect for this.
 
 ## API
-You can `flatMap` as many functions returning `Either` type as you wish. The `flatMap` function will always take the result of the previous function, unwrap it if it's a `Success` and pass it as an argument to the next function.
+
+To handle the end result of a function (or a function chain) returning an `Either` use `fold()`. You can provide lambdas for success and failure cases:
+
+```kotlin
+getUserData().fold(
+    failed = { failure -> showError(failure) },
+    succeeded = { success -> showUserData(success) }
+)
+```
+
+To chain multiple functions, you can use `flatMap {}`. The `flatMap` function will always take the result of the previous function, unwrap it if it's a `Success` and pass it as an argument to the next function.
 
 If any of the flatmapped functions returns a `Failure`, the first `Failure` will be returned to the caller immediately and none of the following functions will be called. This let's you interrupt the call chain if at any of the stages something goes wrong.
 
@@ -34,17 +35,8 @@ connectToServer()
     .flatMap { profile -> saveProfileToDatabase(profile) }
 ```
 
-There is also a `fold` function which can be used to handle the end result of a function (or a function chain) returning an `Either`. You can provide lambdas for success and failure cases.
-
-```kotlin
-getUserData().fold(
-    failed = { failure -> showError(failure) },
-    succeeded = { success -> showUserData(success) }
-)
-```
-
 The `map {}` function can be used to map the **success** value to another value. 
-Imagine we get a `Either<User>` but only want to return the `id` of that user:
+Imagine we get an `Either<User>` but only want to return the `id` of that user:
 
 
 ```kotlin


### PR DESCRIPTION
#### Description:
This improves README. Especially important is the removal of the initial example showing usage of `Either` in a `when` block. This promotes wrong usage of the type, as it should almost never happen in production, it is usually better to use `fold()`. So `fold()` description has been promoted to the first position in the API description.
#### How to test:

#### Merge information: